### PR TITLE
Change envelop format

### DIFF
--- a/policies/aggregation/envelop.js
+++ b/policies/aggregation/envelop.js
@@ -5,18 +5,17 @@ const packageResponses = (req, responses) => ({
   gateway: {
     requestId: req.egContext.requestID,
     request: req.url,
-    numberOfEndpoints: responses.length,
-    listOfEndpoints: responses.map(([endpoint, res]) => (
-      {
-        id: endpoint.id,
+    endpoints: responses.reduce((m, [endpoint, res]) => {
+      m[endpoint.id] = {
         name: endpoint.name,
         url: new URL(req.url, endpoint.url).toString(),
         responseCode: res.statusCode || 0
       }
-    ))
+      return m
+    }, {})
   },
 
-  endpoint: responses.filter(
+  responses: responses.filter(
     ([, res]) => res.statusCode === httpcode.OK
   ).reduce(
     (m, [{ id }, { body }]) => {

--- a/test/aggregation/envelop.test.js
+++ b/test/aggregation/envelop.test.js
@@ -26,25 +26,25 @@ describe('envelop', () => {
         {
           requestId: 'test-request-id',
           request: '/test-url?foo=bar',
-          numberOfEndpoints: 2,
-          listOfEndpoints: [{
-            id: 'endpoint-1',
-            name: 'endpoint-1-name',
-            url: 'http://endpoint-1.org/test-url?foo=bar',
-            responseCode: httpcode.OK
-          }, {
-            id: 'endpoint-2',
-            name: 'endpoint-2-name',
-            url: 'http://endpoint-2.org/test-url?foo=bar',
-            responseCode: httpcode.BadRequest
-          }]
+          endpoints: {
+            'endpoint-1': {
+              name: 'endpoint-1-name',
+              url: 'http://endpoint-1.org/test-url?foo=bar',
+              responseCode: httpcode.OK
+            },
+            'endpoint-2': {
+              name: 'endpoint-2-name',
+              url: 'http://endpoint-2.org/test-url?foo=bar',
+              responseCode: httpcode.BadRequest
+            }
+          }
         }
       )
     })
 
-    it('has an endpoint property', () => {
+    it('has an responses property', () => {
       assert.deepEqual(
-        resp.endpoint,
+        resp.responses,
         { 'endpoint-1': { foo: 'bar' } }
       )
     })

--- a/test/aggregation/integration.test.js
+++ b/test/aggregation/integration.test.js
@@ -9,15 +9,6 @@ const {
   gatewayUrl
 } = require('../integration.environment.js')
 
-// the quickest response gets listed first, sorting stabilizes tests
-const sortListOfEndpoints = (listOfEndpoints) => (
-  listOfEndpoints.sort((a, b) => {
-    if (a.id < b.id) return -1
-    if (a.id > b.id) return 1
-    return 0
-  })
-)
-
 integrationContext('aggregation policy', function () {
   it('should respond with an envelop', async () => {
     const res = await httpGet(gatewayUrl('fred', '/'))
@@ -26,30 +17,25 @@ integrationContext('aggregation policy', function () {
 
     const body = JSON.parse(res.body)
     assert(body.gateway)
-    assert(body.endpoint)
+    assert(body.responses)
 
-    assert.equal(body.gateway.numberOfEndpoints, 2)
     assert.equal(body.gateway.request, '/')
 
     assert.deepEqual(
-      sortListOfEndpoints(
-        body.gateway.listOfEndpoints
-      ),
-      [ // sorted!
-        {
-          id: 'OtherTestBackend',
-          url: 'http://test-backend2/',
-          responseCode: httpcode.OK
-        },
-        {
-          id: 'TestBackend',
+      body.gateway.endpoints,
+      {
+        TestBackend: {
           url: 'http://test-backend/',
           responseCode: httpcode.OK
+        },
+        OtherTestBackend: {
+          url: 'http://test-backend2/',
+          responseCode: httpcode.OK
         }
-      ]
+      }
     )
 
-    assert.deepEqual(body.endpoint, {
+    assert.deepEqual(body.responses, {
       TestBackend: {
         contactEmail: 'user@example.com',
         specification: 'http://example.com',

--- a/test/validation.integration.test.js
+++ b/test/validation.integration.test.js
@@ -70,7 +70,7 @@ integrationContext('validation policy', function () {
       assert.equal(res.statusCode, httpcode.OK)
       assert.match(res.headers['content-type'], /^application\/json\b/)
 
-      const course = JSON.parse(res.body).endpoint.TestBackend
+      const course = JSON.parse(res.body).responses.TestBackend
       assert.equal(course.courseId, '900d900d-900d-900d-900d-900d900d900d')
     })
 
@@ -79,7 +79,7 @@ integrationContext('validation policy', function () {
       assert.equal(res.statusCode, httpcode.OK)
       assert.match(res.headers['content-type'], /^application\/json\b/)
 
-      const course = JSON.parse(res.body).endpoint.TestBackend
+      const course = JSON.parse(res.body).responses.TestBackend
       assert.equal(course.courseId, 'badbadba-badb-badb-badb-badbadbadbad')
     })
   })


### PR DESCRIPTION
The new and improved envelop format:

```
{
  gateway: {
    requestId: "xxxxxxxxxx",
    request: "x://xxxxxxxxx",
    endpoints: {
      xxx: {
        name: "xxxxxxxxxx",
        url: "x://xxxxxxxxx",
        responseCode: 999
      },
      yyy: {
        ...
      }
    ))
  },

  responses: {
    xxx: {
      ...
    },
    yyy: {
      ...
    }
  }
}
```