### PR TITLE
Log x-routes usage

### DIFF
--- a/policies/lifecycle-logger/logger.js
+++ b/policies/lifecycle-logger/logger.js
@@ -15,6 +15,7 @@
  */
 
 const jsonLog = require('../../lib/json_log')
+const xroute = require('../../lib/xroute')
 const ensureTraceParent = require('../../lib/ensure_traceparent')
 
 module.exports = () => {
@@ -23,12 +24,12 @@ module.exports = () => {
     const reqTimerStart = new Date()
     const method = req.method
     const url = req.originalUrl
+    const routes = xroute.decode(req.headers['x-route'])
 
     res.on('finish', () => {
       const app = req.egContext.app // set by gatekeeper policy
       const reqTimerEnd = new Date()
       const statusCode = res.statusCode
-
       const infoProps = {
         side: 'client',
         short_message: `${req.traceparent.traceId} - ${method} ${url} ${statusCode}`,
@@ -40,7 +41,8 @@ module.exports = () => {
         http_status: statusCode,
         request_method: method,
         url,
-        time_ms: reqTimerEnd - reqTimerStart
+        time_ms: reqTimerEnd - reqTimerStart,
+        num_x_routes: routes ? routes.length : 0
       }
 
       if (res.error_msg) {


### PR DESCRIPTION
For incoming requests, log the number of endpoints in the x-routes header. If no x-routes is present, log as "num_x_routes": 0

The num_x_routes value is also exposed as a metric label on incoming_http_requests_total, incoming_concurrent_http_requests, incoming_http_request_duration_seconds