### PR TITLE
Use nonroot distroless container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ COPY . /app
 WORKDIR /app
 RUN npm ci --only=production
 
-FROM gcr.io/distroless/nodejs20-debian12
+FROM gcr.io/distroless/nodejs20-debian12:nonroot
 COPY --from=build-env /app /app
 WORKDIR /app
 CMD ["server.js"]


### PR DESCRIPTION
The server and healthcheck will run as:

  user: nonroot (uid=65532)
  group: nonroot (guid=65532)

I can't find proper documentation but see also:

- https://github.com/GoogleContainerTools/distroless/blob/2ce552d3bd5db0edb82602edbeabcbb5159329d1/common/BUILD.bazel#L123
- https://github.com/GoogleContainerTools/distroless/blob/2ce552d3bd5db0edb82602edbeabcbb5159329d1/common/variables.bzl#L18