### PR TITLE
Disable dev/debug environment for node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,8 @@ COPY --from=build-env /app /app
 WORKDIR /app
 CMD ["server.js"]
 EXPOSE 8080
+
+# Set node to "production" to disable verbose error reports
+ENV NODE_ENV="production"
+
 HEALTHCHECK --interval=30s --timeout=2s --start-period=5s --retries=2 CMD ["/nodejs/bin/node", "healthcheck.js", "||", "exit", "1"]


### PR DESCRIPTION
This disables printing stacktraces at the client when an Error is thrown.

See also PT-SRF-EDH-25A-003