### PR TITLE
Fix request validator no match errors

### DIFF
--- a/policies/openapi-validator/request-validator.js
+++ b/policies/openapi-validator/request-validator.js
@@ -14,27 +14,43 @@
  * with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-const { ValidationError } = require('express-openapi-validate')
-
 const httpcode = require('../../lib/httpcode')
+
+// OpenApiValidator throws generic Error exceptions when no matching
+// method or path can be found. The `allowNoMatch` is broken and would
+// let not matching requests pass.
+
+const NO_MATCH_RE = /\b(method|path)=/i
+
+const isMatchError = (err) => (
+  err instanceof Error && err.message && NO_MATCH_RE.test(err.message)
+)
+
+const sendBadRequest = (res, err) => {
+  res.set('content-type', 'application/json')
+  res.status(httpcode.BadRequest)
+  res.send(JSON.stringify({ message: err.message, data: err.data }))
+  res.error_msg = err.message // we log res.error_msg in lifecycle logger
+}
 
 const makeValidateRequestMiddleware = (validatorFn) => {
   return (req, res, next) => {
-    validatorFn().match()(req, res, (err) => {
-      if (err instanceof ValidationError) {
-        res.set('content-type', 'application/json')
-        res.status(httpcode.BadRequest)
-        res.send(JSON.stringify({ message: err.message, data: err.data }))
-        res.error_msg = err.message // we log res.error_msg in lifecycle logger
-      } else if (err instanceof Error) {
-        res.set('content-type', 'text/plain')
-        res.status(httpcode.InternalServerError)
-        res.error_msg = err.message // we log res.error_msg in lifecycle logger
-        res.send(err.message)
+    try {
+      validatorFn().match()(req, res, (err) => {
+        if (err !== undefined) {
+          // err is always a ValidationError object
+          sendBadRequest(res, err)
+        } else {
+          next()
+        }
+      })
+    } catch (err) {
+      if (isMatchError(err)) {
+        sendBadRequest(res, err)
       } else {
-        next(err)
+        throw err
       }
-    })
+    }
   }
 }
 

--- a/test/validation.integration.test.js
+++ b/test/validation.integration.test.js
@@ -21,6 +21,7 @@ const httpcode = require('../lib/httpcode')
 
 const {
   httpGet,
+  httpPost,
   integrationContext,
   gatewayUrl,
   TEST_OOAPI_VERSION
@@ -42,6 +43,14 @@ if (TEST_OOAPI_VERSION < 6) {
     it('should respond with OK for a correct request with parameter', async () => {
       const res = await httpGet(gatewayUrl('fred', '/courses?pageNumber=1'))
       assert.equal(res.statusCode, httpcode.OK)
+    })
+
+    it('should respond with BadRequest when using wrong method', async () => {
+      const res = await httpPost(gatewayUrl('fred', '/courses'), { params: {} })
+      assert.equal(res.statusCode, httpcode.BadRequest)
+
+      const { message } = JSON.parse(res.body)
+      assert.equal(message, 'Path=/courses with method=post not found from OpenAPI document')
     })
 
     it('should respond with BadRequest when specifying a parameter with the wrong format', async () => {


### PR DESCRIPTION
OpenApiValidator throw generic Error exceptions when no matching method or path can be found.  Make sure a 400 Bad Request is returned in those cases.